### PR TITLE
add post_ln and roberta

### DIFF
--- a/SwissArmyTransformer/arguments.py
+++ b/SwissArmyTransformer/arguments.py
@@ -52,6 +52,8 @@ def add_model_config_args(parser):
                             'This is added for computational efficieny reasons.')
     group.add_argument('--sandwich-ln', action='store_true',
                        help='add sandwich ln in cogview.')
+    group.add_argument('--post-ln', action='store_true',
+                       help='use post layer (standard bert)')
     return parser
 
 

--- a/SwissArmyTransformer/model/base_model.py
+++ b/SwissArmyTransformer/model/base_model.py
@@ -68,6 +68,7 @@ class BaseModel(torch.nn.Module):
                 checkpoint_activations=args.checkpoint_activations,
                 checkpoint_num_layers=args.checkpoint_num_layers,
                 sandwich_ln=args.sandwich_ln,
+                post_ln=args.post_ln,
                 hooks=self.hooks,
                 **kwargs
             )

--- a/examples/roberta/README.md
+++ b/examples/roberta/README.md
@@ -1,0 +1,22 @@
+# swiss-roberta
+
+We transform parameters of [roberta-base](https://huggingface.co/roberta-base) and [roberta-large](https://huggingface.co/roberta-large) from huggingface to swiss by `transform_param.py`.
+
+## Inference
+
+```bash
+bash scripts/inference_roberta.sh base
+bash scripts/inference_roberta.sh large
+```
+
+## Finetune
+
+```bash
+bash scripts/finetune_boolq.sh base
+bash scripts/finetune_boolq.sh large
+```
+
+### Performace
+
+* roberta-base: iteration 1000 validation acc 0.7769
+* roberta-large: iteration 1000 validation acc 0.8504

--- a/examples/roberta/config/model_roberta_base.sh
+++ b/examples/roberta/config/model_roberta_base.sh
@@ -1,0 +1,12 @@
+MODEL_TYPE="swiss-roberta-base"
+MODEL_ARGS="--num-layers 12 \
+            --vocab-size 50265 \
+            --hidden-size 768 \
+            --num-attention-heads 12 \
+            --max-sequence-length 514 \
+            --hidden-dropout 0.1 \
+            --attention-dropout 0.1 \
+            --checkpoint-activations \
+            --checkpoint-num-layers 1 \
+	    --post-ln \
+            --load ${CHECKPOINT_PATH}/$MODEL_TYPE"

--- a/examples/roberta/config/model_roberta_large.sh
+++ b/examples/roberta/config/model_roberta_large.sh
@@ -1,0 +1,12 @@
+MODEL_TYPE="swiss-roberta-large"
+MODEL_ARGS="--num-layers 24 \
+            --vocab-size 50265 \
+            --hidden-size 1024 \
+            --num-attention-heads 16 \
+            --max-sequence-length 514 \
+            --hidden-dropout 0.1 \
+            --attention-dropout 0.1 \
+            --checkpoint-activations \
+            --checkpoint-num-layers 1 \
+	    --post-ln \
+            --load ${CHECKPOINT_PATH}/$MODEL_TYPE"

--- a/examples/roberta/finetune_roberta_boolq.py
+++ b/examples/roberta/finetune_roberta_boolq.py
@@ -1,0 +1,101 @@
+import os
+
+import torch
+import argparse
+import numpy as np
+
+from SwissArmyTransformer import mpu, get_args
+from SwissArmyTransformer.training.deepspeed_training import training_main
+from roberta_model import RobertaModel
+from SwissArmyTransformer.model.mixins import PrefixTuningMixin, MLPHeadMixin
+
+class ClassificationModel(RobertaModel):
+    def __init__(self, args, transformer=None, parallel_output=True):
+        super().__init__(args, transformer=transformer, parallel_output=parallel_output)
+        self.del_mixin('roberta-final')
+        self.add_mixin('classification_head', MLPHeadMixin(args.hidden_size, 2048, 1))
+        self.add_mixin('prefix-tuning', PrefixTuningMixin(args.num_layers, args.hidden_size // args.num_attention_heads, args.num_attention_heads, args.prefix_len))
+    def disable_untrainable_params(self):
+        self.transformer.word_embeddings.requires_grad_(False)
+        # for layer_id in range(len(self.transformer.layers)):
+        #     self.transformer.layers[layer_id].requires_grad_(False)
+
+def get_batch(data_iterator, args, timers):
+    # Items and their type.
+    keys = ['input_ids', 'position_ids', 'attention_mask', 'label']
+    datatype = torch.int64
+
+    # Broadcast data.
+    timers('data loader').start()
+    if data_iterator is not None:
+        data = next(data_iterator)
+    else:
+        data = None
+    timers('data loader').stop()
+    data_b = mpu.broadcast_data(keys, data, datatype)
+    # Unpack.
+    tokens = data_b['input_ids'].long()
+    labels = data_b['label'].long()
+    position_ids = data_b['position_ids'].long()
+    attention_mask = data_b['attention_mask'][:, None, None, :].float()
+
+    # Convert
+    if args.fp16:
+        attention_mask = attention_mask.half()
+    
+    return tokens, labels, attention_mask, position_ids, (tokens!=1)
+
+
+def forward_step(data_iterator, model, args, timers):
+    """Forward step."""
+
+    # Get the batch.
+    timers('batch generator').start()
+    tokens, labels, attention_mask, position_ids, loss_mask = get_batch(
+        data_iterator, args, timers)
+    timers('batch generator').stop()
+
+    logits, *mems = model(tokens, position_ids, attention_mask)
+    # pred = ((logits.contiguous().float().squeeze(-1)) * loss_mask).sum(dim=-1) / loss_mask.sum(dim=-1)
+    pred = logits.contiguous().float().squeeze(-1)[..., 0]
+    loss = torch.nn.functional.binary_cross_entropy_with_logits(
+        pred,
+        labels.float()
+    )
+    acc = ((pred > 0.).long() == labels).sum() / labels.numel()
+    return loss, {'acc': acc}
+
+pretrain_path = '/data/qingsong/pretrain'
+from transformers import RobertaTokenizer
+tokenizer = RobertaTokenizer.from_pretrained(os.path.join(pretrain_path, 'roberta-base'))
+from transformers.models.roberta.modeling_roberta import create_position_ids_from_input_ids
+
+def _encode(text, text_pair):
+    encoded_input = tokenizer(text, text_pair, max_length=args.sample_length, padding='max_length', truncation='only_first')
+    position_ids = create_position_ids_from_input_ids(torch.tensor([encoded_input['input_ids']]), 1, 0)
+    return dict(input_ids=encoded_input['input_ids'], position_ids=position_ids[0].numpy(), attention_mask=encoded_input['attention_mask'])
+
+from SwissArmyTransformer.data_utils import load_hf_dataset
+def create_dataset_function(path, args):
+    def process_fn(row):
+        pack, label = _encode(row['passage'], row['question']), int(row['label'])
+        return {
+            'input_ids': np.array(pack['input_ids'], dtype=np.int64),
+            'position_ids': np.array(pack['position_ids'], dtype=np.int64),
+            'attention_mask': np.array(pack['attention_mask'], dtype=np.int64),
+            'label': label
+        }
+    return load_hf_dataset(path, process_fn, columns = ["input_ids", "position_ids", "attention_mask", "label"], cache_dir='/data/qingsong/dataset', offline=False)
+
+if __name__ == '__main__':
+    py_parser = argparse.ArgumentParser(add_help=False)
+    py_parser.add_argument('--new_hyperparam', type=str, default=None)
+    py_parser.add_argument('--sample_length', type=int, default=512-16)
+    py_parser.add_argument('--prefix_len', type=int, default=16)
+    py_parser.add_argument('--old_checkpoint', action="store_true")
+    known, args_list = py_parser.parse_known_args()
+    args = get_args(args_list)
+    args = argparse.Namespace(**vars(args), **vars(known))
+    # from cogdata.utils.ice_tokenizer import get_tokenizer as get_ice
+    # tokenizer = get_tokenizer(args=args, outer_tokenizer=get_ice())
+    training_main(args, model_cls=ClassificationModel, forward_step_function=forward_step, create_dataset_function=create_dataset_function)

--- a/examples/roberta/inference_roberta.py
+++ b/examples/roberta/inference_roberta.py
@@ -1,0 +1,52 @@
+import os
+import argparse
+from SwissArmyTransformer import get_args
+py_parser = argparse.ArgumentParser(add_help=False)
+py_parser.add_argument('--pretrain_path', type=str, default=None)
+py_parser.add_argument('--old_checkpoint', action="store_true")
+known, args_list = py_parser.parse_known_args()
+args = get_args(args_list)
+args = argparse.Namespace(**vars(args), **vars(known))
+pretrain_path = args.pretrain_path
+model_type = '-'.join(args.load.split('/')[-1].split('-')[1:])
+print(model_type)
+
+import os
+import torch
+init_method = 'tcp://'
+master_ip = os.getenv('MASTER_ADDR', '127.0.0.1')
+master_port = os.getenv('MASTER_PORT', '16666')
+init_method += master_ip + ':' + master_port
+torch.distributed.init_process_group(
+        backend='nccl',
+        world_size=args.world_size, rank=args.rank, init_method=init_method)
+
+import SwissArmyTransformer.mpu as mpu
+mpu.initialize_model_parallel(args.model_parallel_size)
+
+from roberta_model import RobertaModel
+from SwissArmyTransformer.training.deepspeed_training import load_checkpoint
+model = RobertaModel(args)
+load_checkpoint(model, args)
+
+from transformers.models.roberta.modeling_roberta import create_position_ids_from_input_ids
+from transformers import RobertaTokenizer, RobertaForMaskedLM
+tokenizer = RobertaTokenizer.from_pretrained(os.path.join(pretrain_path, model_type))
+roberta = RobertaForMaskedLM.from_pretrained(os.path.join(pretrain_path, model_type), output_hidden_states=True)
+
+model.eval()
+with torch.no_grad():
+    text = ["This is a piece of text.", "Another piece of text."]
+    encoded_input = tokenizer(text, return_tensors='pt', padding=True)
+    hugging_output = roberta(**encoded_input)[0]
+    position_ids = create_position_ids_from_input_ids(encoded_input['input_ids'], 1, 0)
+    print(position_ids)
+    model.to('cuda:0')
+    swiss_output = model(input_ids=encoded_input['input_ids'].cuda(), position_ids=position_ids.cuda(), attention_mask=encoded_input['attention_mask'][:, None, None, :].cuda())[0].cpu()
+    # Since we don't use padding_idx for Embedding layers, pad output is largely different between hugging and swiss.
+    # You will find it if you calculate error for hugging_output[1] and swiss_output[1].
+    # However, pad output is usually not used, it doesn't matter too much.
+    print("max error:", (hugging_output[0] - swiss_output[0]).abs().max())
+    print("max relative error:", ((hugging_output[0] - swiss_output[0]).abs() / torch.max(swiss_output[0].abs(), hugging_output[0].abs())).max())
+
+# breakpoint()

--- a/examples/roberta/roberta_model.py
+++ b/examples/roberta/roberta_model.py
@@ -1,0 +1,35 @@
+import torch
+import torch.nn as nn
+from SwissArmyTransformer.mpu.transformer import LayerNorm
+from SwissArmyTransformer.model.base_model import BaseMixin, BaseModel
+
+roberta_gelu = nn.functional.gelu
+
+class roberta_lm_head(torch.nn.Module):
+    def __init__(self, vocab_size, hidden_size, layernorm_epsilon=1.0e-5):
+        super().__init__()
+        self.dense = nn.Linear(hidden_size, hidden_size)
+        self.layer_norm = LayerNorm(hidden_size, eps=layernorm_epsilon)
+        self.decoder = nn.Linear(hidden_size, vocab_size)
+    
+    def forward(self, x):
+        x = self.dense(x)
+        x = roberta_gelu(x)
+        x = self.layer_norm(x)
+        x = self.decoder(x)
+        return x
+
+class RobertaFinalMixin(BaseMixin):
+    def __init__(self, vocab_size, hidden_size):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.lm_head = roberta_lm_head(vocab_size, hidden_size)
+
+    def final_forward(self, logits, **kwargs):
+        return self.lm_head(logits)
+
+
+class RobertaModel(BaseModel):
+    def __init__(self, args, transformer=None, **kwargs):
+        super(RobertaModel, self).__init__(args, transformer=transformer, activation_func=roberta_gelu, **kwargs)
+        self.add_mixin("roberta-final", RobertaFinalMixin(args.vocab_size, args.hidden_size))

--- a/examples/roberta/scripts/ds_config_ft.json
+++ b/examples/roberta/scripts/ds_config_ft.json
@@ -1,0 +1,30 @@
+{
+  "train_micro_batch_size_per_gpu":64,
+  "gradient_accumulation_steps": 1,
+  "steps_per_print": 10,
+  "gradient_clipping": 0.1,
+  "fp16": {
+    "enabled": true,
+    "loss_scale": 0,
+    "loss_scale_window": 400,
+    "hysteresis": 2,
+    "min_loss_scale": 1
+  },
+  "optimizer": {
+    "type": "Adam",
+    "params": {
+      "lr": 0.00001,
+      "betas": [
+        0.9,
+        0.95
+      ],
+      "eps": 1e-8,
+      "weight_decay": 0
+    }
+  },
+  "activation_checkpointing": {
+    "partition_activations": false,
+    "contiguous_memory_optimization": false
+  },
+  "wall_clock_breakdown": false
+}

--- a/examples/roberta/scripts/finetune_boolq.sh
+++ b/examples/roberta/scripts/finetune_boolq.sh
@@ -1,0 +1,59 @@
+#! /bin/bash
+
+# Change for multinode config
+CHECKPOINT_PATH=/data/qingsong/pretrain
+
+NUM_WORKERS=1
+NUM_GPUS_PER_WORKER=8
+MP_SIZE=1
+
+script_path=$(realpath $0)
+script_dir=$(dirname $script_path)
+main_dir=$(dirname $script_dir)
+source $main_dir/config/model_roberta_$1.sh
+echo $MODEL_TYPE
+
+OPTIONS_NCCL="NCCL_DEBUG=info NCCL_IB_DISABLE=0 NCCL_NET_GDR_LEVEL=2"
+HOST_FILE_PATH="hostfile"
+HOST_FILE_PATH="hostfile_single"
+
+en_data="hf://super_glue/boolq/train"
+eval_data="super_glue/boolq/validation"
+test_data="super_glue/boolq/test"
+
+config_json="$script_dir/ds_config_ft.json"
+gpt_options=" \
+       --experiment-name finetune-$MODEL_TYPE-boolq \
+       --model-parallel-size ${MP_SIZE} \
+       --mode finetune \
+       --train-iters 1000 \
+       --resume-dataloader \
+       $MODEL_ARGS \
+       --train-data ${en_data} \
+       --valid-data ${eval_data} \
+       --distributed-backend nccl \
+       --lr-decay-style cosine \
+       --warmup .02 \
+       --checkpoint-activations \
+       --fp16 \
+       --save-interval 1000 \
+       --eval-interval 100 \
+       --save /data/qingsong/checkpoints \
+       --split 1 \
+       --strict-eval \
+       --eval-batch-size 8
+"
+
+
+
+gpt_options="${gpt_options}
+       --deepspeed \
+       --deepspeed_config ${config_json} \
+"
+
+
+run_cmd="${OPTIONS_NCCL} deepspeed --num_nodes ${NUM_WORKERS} --num_gpus ${NUM_GPUS_PER_WORKER} --hostfile ${HOST_FILE_PATH} finetune_roberta_boolq.py ${gpt_options}"
+echo ${run_cmd}
+eval ${run_cmd}
+
+set +x

--- a/examples/roberta/scripts/inference_roberta.sh
+++ b/examples/roberta/scripts/inference_roberta.sh
@@ -1,0 +1,15 @@
+#! /bin/bash
+
+# Change for multinode config
+CHECKPOINT_PATH=/data/qingsong/pretrain
+
+script_path=$(realpath $0)
+script_dir=$(dirname $script_path)
+main_dir=$(dirname $script_dir)
+source $main_dir/config/model_roberta_$1.sh
+
+run_cmd="python inference_roberta.py --pretrain_path $CHECKPOINT_PATH --mode inference $MODEL_ARGS"
+echo ${run_cmd}
+eval ${run_cmd}
+
+set +x

--- a/examples/roberta/transform_param.py
+++ b/examples/roberta/transform_param.py
@@ -1,0 +1,114 @@
+import os
+pretrain_path = '/data/qingsong/pretrain'
+
+from transformers import RobertaTokenizer, RobertaForMaskedLM
+tokenizer = RobertaTokenizer.from_pretrained(os.path.join(pretrain_path, 'roberta-base'))
+roberta = RobertaForMaskedLM.from_pretrained(os.path.join(pretrain_path, 'roberta-base'), output_hidden_states=True)
+lm_head = roberta.lm_head
+roberta = roberta.roberta
+
+import argparse
+args = argparse.Namespace(
+    num_layers=12,
+    vocab_size=50265,
+    hidden_size=768,
+    num_attention_heads=12,
+    max_sequence_length=514,
+    hidden_dropout=0.1,
+    attention_dropout=0.1,
+    inner_hidden_size=None,
+    hidden_size_per_attention_head=None,
+    checkpoint_activations=True,
+    checkpoint_num_layers=1,
+    sandwich_ln=False,
+    model_parallel_size=1,
+    world_size=1,
+    rank=0
+    )
+
+import torch
+init_method = 'tcp://'
+master_ip = os.getenv('MASTER_ADDR', '127.0.0.1')
+master_port = os.getenv('MASTER_PORT', '16666')
+init_method += master_ip + ':' + master_port
+torch.distributed.init_process_group(
+        backend='nccl',
+        world_size=args.world_size, rank=args.rank, init_method=init_method)
+
+import SwissArmyTransformer.mpu as mpu
+mpu.initialize_model_parallel(args.model_parallel_size)
+
+from roberta_model import RobertaModel
+model = RobertaModel(args)
+
+def copy_layer_param(src, dst):
+    """
+    in-place copy from src to dst
+    src and dst should be the same layer type, e.g., both are LayerNorm or both are Linear.
+        Or at least, both have same named_parameters name and shape.
+    """
+    src_dic = dict(src.named_parameters())
+    dst_dic = dict(dst.named_parameters())
+    for k in dst_dic:
+        assert dst_dic[k].data.shape == src_dic[k].data.shape
+        dst_dic[k].data = src_dic[k].data
+        assert (dst_dic[k].data == src_dic[k].data).all()
+
+def copy_layer_norm(src, dst):
+    src_ln = []
+    for k, v in src.named_parameters():
+        if 'layernorm' in k.lower():
+            src_ln.append((k, v))
+    dst_ln = []
+    for k, v in dst.named_parameters():
+        if 'layernorm' in k.lower():
+            dst_ln.append((k, v))
+    assert len(src_ln) == len(dst_ln)
+    for kvs, kvd in zip(src_ln, dst_ln):
+        assert kvd[1].data.shape == kvs[1].data.shape
+        kvd[1].data = kvs[1].data
+        assert (kvd[1].data == kvs[1].data).all()
+
+def copy_transformer_layer_wo_ln(src, dst):
+    new_weight = torch.cat([src.attention.self.query.weight.data, src.attention.self.key.weight.data, src.attention.self.value.weight.data], 0)
+    assert dst.attention.query_key_value.weight.data.shape == new_weight.shape
+    dst.attention.query_key_value.weight.data = new_weight
+    new_bias = torch.cat([src.attention.self.query.bias.data, src.attention.self.key.bias.data, src.attention.self.value.bias.data], 0)
+    assert dst.attention.query_key_value.bias.data.shape == new_bias.shape
+    dst.attention.query_key_value.bias.data = new_bias
+    copy_layer_param(src.attention.output.dense, dst.attention.dense)
+    copy_layer_param(src.intermediate.dense, dst.mlp.dense_h_to_4h)
+    copy_layer_param(src.output.dense, dst.mlp.dense_4h_to_h)
+
+def transform_weight(hugging_model, swiss_model):
+    copy_layer_param(hugging_model.embeddings.word_embeddings, swiss_model.transformer.word_embeddings)
+    copy_layer_param(hugging_model.embeddings.position_embeddings, swiss_model.transformer.position_embeddings)
+    # swiss_model.transformer.word_embeddings.padding_idx = roberta.embeddings.padding_idx
+    # swiss_model.transformer.position_embeddings.padding_idx = roberta.embeddings.padding_idx
+    copy_layer_norm(hugging_model, swiss_model)
+    for src_l, dst_l in zip(hugging_model.encoder.layer, swiss_model.transformer.layers):
+        copy_transformer_layer_wo_ln(src_l, dst_l)
+    copy_layer_param(lm_head.dense, model.mixins['roberta-final'].lm_head.dense)
+    copy_layer_param(lm_head.layer_norm, model.mixins['roberta-final'].lm_head.layer_norm)
+    copy_layer_param(lm_head.decoder, model.mixins['roberta-final'].lm_head.decoder)
+    
+
+from transformers.models.roberta.modeling_roberta import create_position_ids_from_input_ids
+
+roberta.eval()
+model.eval()
+with torch.no_grad():
+    transform_weight(roberta, model)
+    text = ["This is a piece of text.", "Another piece of text."]
+    encoded_input = tokenizer(text, return_tensors='pt', padding=True)
+    position_ids = create_position_ids_from_input_ids(encoded_input['input_ids'], roberta.embeddings.padding_idx, 0)
+    print(position_ids)
+    output = roberta(**encoded_input)
+    hugging_output = lm_head(output[0])
+    model.to('cuda:0')
+    swiss_output = model(input_ids=encoded_input['input_ids'].cuda(), position_ids=position_ids.cuda(), attention_mask=encoded_input['attention_mask'][:, None, None, :].cuda())[0].cpu()
+    print("max error:", (hugging_output[0] - swiss_output[0]).abs().max())
+    print("max relative error:", ((hugging_output[0] - swiss_output[0]).abs() / torch.max(swiss_output[0].abs(), hugging_output[0].abs())).max())
+    torch.save(model.state_dict(), os.path.join(pretrain_path, "roberta-base.pt"))
+
+# breakpoint()


### PR DESCRIPTION
A new argument "post-ln" is added to BaseTransformerLayer, which is necessary in my opinion.

post-ln is used by standard bert, the code to adapt standard bert model (as you can see in examples/roberta) will be cleaner after post-ln is added.

To avoid conflict of sandwich-ln and post-ln, I add `assert not (sandwich_ln and post_ln)`.

The code added here does not have any effect on the existing code, because the default value of post-ln is False.

The only thing confuses me is the `is_decoder` part. I'm not sure whether the modification of post-ln will effect decoder part or not.

However, this is just a suggestion, we can discuss further.