### PR TITLE
Fix the grammar issue for iterable unpacking in the return statements in Python before 3.8

### DIFF
--- a/SwissArmyTransformer/model/encoder_decoder_model.py
+++ b/SwissArmyTransformer/model/encoder_decoder_model.py
@@ -84,7 +84,7 @@ class EncoderDecoderModel(torch.nn.Module):
             cross_attention_mask = enc_attention_mask
         encoder_outputs = self.encode(enc_input_ids, enc_position_ids, enc_attention_mask, **kw_args)
         decoder_outputs, *mems = self.decode(dec_input_ids, dec_position_ids, dec_attention_mask, encoder_outputs=encoder_outputs, cross_attention_mask=cross_attention_mask, **kw_args)
-        return encoder_outputs, decoder_outputs, *mems
+        return (encoder_outputs, decoder_outputs, *mems)
 
     @classmethod
     def add_model_specific_args(cls, parser):

--- a/SwissArmyTransformer/model/official/cait_model.py
+++ b/SwissArmyTransformer/model/official/cait_model.py
@@ -193,4 +193,4 @@ class CaiT(EncoderDecoderModel):
             cross_attention_mask = enc_attention_mask
         encoder_outputs = self.encode(input_ids, enc_position_ids, enc_attention_mask, **kw_args)
         decoder_outputs, *mems = self.decode(input_ids, dec_position_ids, dec_attention_mask, encoder_outputs=encoder_outputs, cross_attention_mask=cross_attention_mask, **kw_args)
-        return encoder_outputs, decoder_outputs, *mems
+        return (encoder_outputs, decoder_outputs, *mems)

--- a/SwissArmyTransformer/model/official/t5_model.py
+++ b/SwissArmyTransformer/model/official/t5_model.py
@@ -284,4 +284,4 @@ class T5Model(EncoderDecoderModel):
         decoder_outputs, *mems = self.decode(dec_input_ids, dec_attention_mask,
                                              encoder_outputs=encoder_outputs, cross_attention_mask=cross_attention_mask,
                                              **kw_args)
-        return encoder_outputs, decoder_outputs, *mems
+        return (encoder_outputs, decoder_outputs, *mems)


### PR DESCRIPTION
Hi, I noticed that using this package with Python 3.7 will result in Syntax Error while I was testing CogView2. 

If I recall correctly, that is a deficiency of Python grammar specification before Python 3.8, which only allows parenthesized unpacking in the return statements[^1].

And here is a fix for this issue. 

Related issue:

- https://github.com/THUDM/CogView2/issues/4

[^1]: https://docs.python.org/3.7/reference/grammar.html