### PR TITLE
Re-set cross attention forward parameter for T5

### DIFF
--- a/SwissArmyTransformer/transformer_defaults.py
+++ b/SwissArmyTransformer/transformer_defaults.py
@@ -94,7 +94,7 @@ def cross_attention_forward_default(self, hidden_states, cross_attention_mask, e
     key_layer = self._transpose_for_scores(mixed_key_layer)
     value_layer = self._transpose_for_scores(mixed_value_layer)
 
-    context_layer = attention_fn(query_layer, key_layer, value_layer, cross_attention_mask, dropout_fn, **kw_args)
+    context_layer = attention_fn(query_layer, key_layer, value_layer, cross_attention_mask, dropout_fn, cross_attention=True, **kw_args)
     context_layer = context_layer.permute(0, 2, 1, 3).contiguous()
     new_context_layer_shape = context_layer.size()[:-2] + (self.hidden_size_per_partition,)
     # [b, s, hp]


### PR DESCRIPTION
It looks like this parameter may have been lost around https://github.com/THUDM/SwissArmyTransformer/commit/d5f676c92e76877251bb9078dc6a510e6b95d526#diff-d58d208b2028dd40c3372abcc9b104b11fc81284fc8489e495b31404d967475cL233-L236 , but it is still used in a couple models: https://github.com/THUDM/SwissArmyTransformer/blob/main/SwissArmyTransformer/model/official/t5_model.py#L116-L119