### PR TITLE
Specify the deepspeed requirement version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 torch
-deepspeed
+deepspeed<0.6
 sentencepiece
 tensorboardX
 datasets


### PR DESCRIPTION
It looks to me like the code has not been forward-ported for deepspeed>=0.6 . It runs better for me with this change for now.