### PR TITLE
dynamic loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 0. change the package name from `SwissArmyTransformer` to `sat` when importing, e.g. `from sat import get_args`.
 1. delete all `--sandwich-ln` in you script, use `layernorm-order='sandwich'`.
 2. change order `from_pretrained(args, name) => from_pretrained(name, args)`.
-4. We can directly use `from sat.model import AutoModel;model, args = AutoModel.from_pretrained(‘roberta-base’)` to load model in `model-only` mode, instead of initializing the sat first. 
+4. We can directly use `from sat.model import AutoModel;model, args = AutoModel.from_pretrained('roberta-base')` to load model in `model-only` mode, instead of initializing the sat first. 
 
 ## Install
 ```
@@ -171,7 +171,7 @@ TO BE RELEASED SOON...
 # Citation
 Currently we don't have a paper, so you don't need to formally cite us!~ 
 
-If this project helps your research or engineering, use `\footnote{https://github.com/THUDM/sat}` to mention us and recommend `sat` to others.
+If this project helps your research or engineering, use `\footnote{https://github.com/THUDM/SwissArmyTransformer}` to mention us and recommend `SwissArmyTransformer` to others.
 
 The tutorial for contributing sat is on the way!
 

--- a/sat/model/base_model.py
+++ b/sat/model/base_model.py
@@ -16,7 +16,7 @@ import torch
 import inspect
 import warnings
 import argparse
-
+from sat.model.registry import model_registry
 
 
 from sat.model.transformer import BaseTransformer, standard_attention
@@ -72,7 +72,7 @@ class BaseMixin(torch.nn.Module):
     #     attn_result = post_hack(attn_result)
     #     return attn_result
 
-
+@model_registry.register
 class BaseModel(torch.nn.Module):
     def __init__(self, args, transformer=None, params_dtype=torch.float, **kwargs):
         super(BaseModel, self).__init__()
@@ -185,7 +185,7 @@ class BaseModel(torch.nn.Module):
         return parser
 
     @classmethod
-    def from_pretrained(cls, name, args=None, *, home_path=None, url=None, prefix='', **kwargs):
+    def from_pretrained(cls, name, args=None, *, home_path=None, url=None, prefix='', build_only=False, **kwargs):
         '''Load a pretrained checkpoint of the current model.
             Args:
                 name: The identifier of the pretrained model.
@@ -206,7 +206,8 @@ class BaseModel(torch.nn.Module):
             args = cls.get_args()
         args = update_args_with_file(args, path=os.path.join(model_path, 'model_config.json'))
         model = get_model(args, cls, **kwargs)
-        load_checkpoint(model, args, load_path=model_path, prefix=prefix)
+        if not build_only:
+            load_checkpoint(model, args, load_path=model_path, prefix=prefix)
         return model, args
     
     @classmethod
@@ -243,7 +244,7 @@ class BaseModel(torch.nn.Module):
 
 class AutoModel():
     @classmethod
-    def from_pretrained(cls, name, args=None, *, home_path=None, url=None, prefix='', **kwargs):
+    def from_pretrained(cls, name, args=None, *, home_path=None, url=None, prefix='', build_only=False, **kwargs):
         '''Automatically find the class and instantiate it. Auto-download.
             Args:
                 name: The identifier of the pretrained model.
@@ -263,12 +264,7 @@ class AutoModel():
         args = update_args_with_file(args, path=os.path.join(model_path, 'model_config.json'))
         if not hasattr(args, 'model_class'):
             raise ValueError('model_config.json must have key "model_class" for AutoModel.from_pretrained.')
-        import sat.model
-        if not hasattr(sat.model, args.model_class): 
-            # TODO dynamic loading
-            raise ValueError(f'model_class {args.model_class} not found.')
-        else:
-            model_cls = getattr(sat.model, args.model_class)
+        model_cls = model_registry.get(args.model_class)
         if null_args:
             # fill args with default values, if not provided
             model_default_args = model_cls.get_args()
@@ -276,5 +272,6 @@ class AutoModel():
                 if not hasattr(args, k):
                     setattr(args, k, v)
         model = get_model(args, model_cls, **kwargs)
-        load_checkpoint(model, args, load_path=model_path, prefix=prefix)
+        if not build_only:
+            load_checkpoint(model, args, load_path=model_path, prefix=prefix)
         return model, args

--- a/sat/model/cached_autoregressive_model.py
+++ b/sat/model/cached_autoregressive_model.py
@@ -38,7 +38,8 @@ class CachedAutoregressiveMixin(BaseMixin):
                 v = torch.cat((memv, v), dim=2)
         return old_impl(q, k, v, mask, dropout_fn, cross_attention=cross_attention, mems=mems, **kw_args)
 
-
+from sat.model.registry import model_registry
+@model_registry.register
 class CachedAutoregressiveModel(BaseModel):
     def __init__(self, args, transformer=None):
         super().__init__(args, transformer=transformer)

--- a/sat/model/encoder_decoder_model.py
+++ b/sat/model/encoder_decoder_model.py
@@ -24,7 +24,8 @@ class EncoderFinalMixin(BaseMixin):
         logits = copy_to_model_parallel_region(logits)
         return logits
 
-
+from sat.model.registry import model_registry
+@model_registry.register
 class EncoderDecoderModel(torch.nn.Module):
     def __init__(self, args, encoder=None, decoder=None, tie_word_embeddings=True, parallel_output=False, **kwargs):
         super(EncoderDecoderModel, self).__init__()

--- a/sat/model/official/bert_model.py
+++ b/sat/model/official/bert_model.py
@@ -35,6 +35,8 @@ class BertTypeMixin(BaseMixin):
     def word_embedding_forward(self, input_ids, **kwargs):
         return self.transformer.word_embeddings(input_ids) + self.type_embeddings(kwargs["token_type_ids"])
 
+from sat.model.registry import model_registry
+@model_registry.register
 class BertModel(BaseModel):
     def __init__(self, args, transformer=None, **kwargs):
         super(BertModel, self).__init__(args, transformer=transformer, activation_func=gelu, **kwargs)

--- a/sat/model/official/cait_model.py
+++ b/sat/model/official/cait_model.py
@@ -6,6 +6,7 @@ from sat.model.base_model import BaseMixin, BaseModel, non_conflict
 from sat.model.official.vit_model import ViTModel, ClsMixin
 from sat.model.mixins import BaseMixin
 from sat import mpu
+from sat.model.registry import model_registry
 
 class AttnMixin(BaseMixin):
     def __init__(self, num_heads, num_layers):
@@ -171,6 +172,7 @@ class CaiTDecoder(BaseModel):
 from sat.model import EncoderDecoderModel
 import argparse
 
+@model_registry.register
 class CaiT(EncoderDecoderModel):
     def __init__(self, args, transformer=None, parallel_output=True, layernorm_epsilon=1e-6):
         encoder = CaiTEncoder(args, transformer=transformer, parallel_output=parallel_output, layernorm_epsilon=layernorm_epsilon)

--- a/sat/model/official/chatglm_model.py
+++ b/sat/model/official/chatglm_model.py
@@ -164,7 +164,9 @@ class ChatGLMLayerMixin(BaseMixin):
             output = hidden_states + mlp_output
 
         return output
-    
+
+from sat.model.registry import model_registry
+@model_registry.register
 class ChatGLMModel(BaseModel):
     def __init__(self, args, transformer=None, **kwargs):
         super(ChatGLMModel, self).__init__(args, transformer=transformer, activation_func=gelu, **kwargs)

--- a/sat/model/official/clip_model.py
+++ b/sat/model/official/clip_model.py
@@ -94,6 +94,8 @@ class TextEncoder(BaseModel):
 
 import argparse
 
+from sat.model.registry import model_registry
+@model_registry.register
 class CLIP(nn.Module):
     def __init__(self, args, layernorm_epsilon=1e-5):
         super().__init__()

--- a/sat/model/official/cuda2d_model.py
+++ b/sat/model/official/cuda2d_model.py
@@ -70,6 +70,8 @@ class AttentionMixin(BaseMixin):
             self.dense[layer_id].weight.data.copy_(old_attention.dense.weight.data)
             self.dense[layer_id].bias.data.copy_(old_attention.dense.bias.data)
 
+from sat.model.registry import model_registry
+@model_registry.register
 class Cuda2dModel(BaseModel):
     def __init__(self, args, transformer=None):
         super().__init__(args, transformer=transformer)

--- a/sat/model/official/distill_model.py
+++ b/sat/model/official/distill_model.py
@@ -1,5 +1,7 @@
 import torch.nn as nn
 
+from sat.model.registry import model_registry
+@model_registry.register
 class DistillModel(nn.Module):
     def __init__(self, teacher, student):
         super().__init__()

--- a/sat/model/official/dpr_model.py
+++ b/sat/model/official/dpr_model.py
@@ -53,6 +53,8 @@ class DPRTypeMixin(BaseMixin):
             token_type_ids = torch.zeros(input_ids.shape, dtype=torch.long).to(input_ids.device)
         return self.transformer.word_embeddings(input_ids) + self.type_embeddings(token_type_ids)
 
+from sat.model.registry import model_registry
+@model_registry.register
 class DPRQuestionEncoder(BaseModel):
     def __init__(self, args, transformer=None, **kwargs):
         super(DPRQuestionEncoder, self).__init__(args, transformer=transformer, **kwargs)
@@ -65,6 +67,7 @@ class DPRQuestionEncoder(BaseModel):
         group.add_argument('--num-types', type=int)
         return parser
 
+@model_registry.register
 class DPRContextEncoder(BaseModel):
     def __init__(self, args, transformer=None, **kwargs):
         super(DPRContextEncoder, self).__init__(args, transformer=transformer, **kwargs)
@@ -77,6 +80,7 @@ class DPRContextEncoder(BaseModel):
         group.add_argument('--num-types', type=int)
         return parser
 
+@model_registry.register
 class DPRReader(BaseModel):
     def __init__(self, args, transformer=None, **kwargs):
         super(DPRReader, self).__init__(args, transformer=transformer, **kwargs)

--- a/sat/model/official/eva2_model.py
+++ b/sat/model/official/eva2_model.py
@@ -121,7 +121,8 @@ class EVA2AttnMixin(BaseMixin):
             output = self.output_dropout(output)
         return output
 
-
+from sat.model.registry import model_registry
+@model_registry.register
 class EVA2Model(BaseModel):
     def __init__(self, args, transformer=None, parallel_output=True, **kwargs):
         self.property = ViTProperty(args.image_size, args.patch_size, args.pre_len, args.post_len)

--- a/sat/model/official/glm130B_model.py
+++ b/sat/model/official/glm130B_model.py
@@ -334,7 +334,8 @@ class WordEmbedding(BaseMixin):
     def word_embedding_forward(self, input_ids, output_cross_layer, **kw_args):
         return self.transformer.word_embeddings(input_ids).transpose(0, 1)
 
-
+from sat.model.registry import model_registry
+@model_registry.register
 class GLM130B(BaseModel):
     def __init__(self, args, transformer=None, parallel_output=False):
         super().__init__(

--- a/sat/model/official/glm_model.py
+++ b/sat/model/official/glm_model.py
@@ -17,6 +17,8 @@ class BlockPositionEmbeddingMixin(BaseMixin):
         block_position_embeddings = self.block_position_embeddings(block_position_ids)
         return position_embeddings + block_position_embeddings
 
+from sat.model.registry import model_registry
+@model_registry.register
 class GLMModel(BaseModel):
     def __init__(self, args, transformer=None, parallel_output=True):
         super().__init__(args, transformer=transformer, parallel_output=parallel_output)

--- a/sat/model/official/gpt2_model.py
+++ b/sat/model/official/gpt2_model.py
@@ -61,6 +61,8 @@ class GPT2AttnMixin(BaseMixin):
         context_layer = torch.matmul(attention_probs, value_layer)
         return context_layer
 
+from sat.model.registry import model_registry
+@model_registry.register
 class GPT2Model(BaseModel):
     def __init__(self, args, transformer=None, **kwargs):
         super(GPT2Model, self).__init__(args, transformer=transformer, activation_func=gelu, **kwargs)

--- a/sat/model/official/gptneo_model.py
+++ b/sat/model/official/gptneo_model.py
@@ -81,6 +81,8 @@ class GPTNeoAttentionMixin(BaseMixin):
         context_layer = torch.matmul(attention_probs, value_layer)
         return context_layer
 
+from sat.model.registry import model_registry
+@model_registry.register
 class GPTNeoModel(BaseModel):
     def __init__(self, args, transformer=None, **kwargs):
         super().__init__(args, transformer, **kwargs)

--- a/sat/model/official/mae_model.py
+++ b/sat/model/official/mae_model.py
@@ -131,7 +131,8 @@ class MAEDecoder(BaseModel):
 
 from sat.model import EncoderDecoderModel
 import argparse
-
+from sat.model.registry import model_registry
+@model_registry.register
 class MAE(EncoderDecoderModel):
     def __init__(self, args, transformer=None, parallel_output=True, layernorm_epsilon=1e-6):
         encoder = MAEEncoder(args, transformer=transformer, parallel_output=parallel_output, layernorm_epsilon=layernorm_epsilon)

--- a/sat/model/official/roberta_model.py
+++ b/sat/model/official/roberta_model.py
@@ -1,5 +1,6 @@
 from sat.model.official.bert_model import BertModel
-
+from sat.model.registry import model_registry
+@model_registry.register
 class RobertaModel(BertModel):
     def __init__(self, args, transformer=None, **kwargs):
         super(RobertaModel, self).__init__(args, transformer=transformer, **kwargs)

--- a/sat/model/official/t5_model.py
+++ b/sat/model/official/t5_model.py
@@ -189,7 +189,8 @@ class T5GatedGeluMLPMixin(BaseMixin):
             output = mlp_module.dropout(output)
         return output
 
-
+from sat.model.registry import model_registry
+@model_registry.register
 class T5Model(EncoderDecoderModel):
     def __init__(self, args, **kwargs):
         self.init_method_std = args.init_method_std

--- a/sat/model/official/vit_model.py
+++ b/sat/model/official/vit_model.py
@@ -137,7 +137,8 @@ class ClsMixin(BaseMixin):
         logits = self.classifier(logits[:, 0])
         return logits
 
-
+from sat.model.registry import model_registry
+@model_registry.register
 class ViTModel(BaseModel):
     def __init__(self, args, transformer=None, parallel_output=True, **kwargs):
         self.property = ViTProperty(args.image_size, args.patch_size, args.pre_len, args.post_len)

--- a/sat/model/official/yolos_model.py
+++ b/sat/model/official/yolos_model.py
@@ -46,6 +46,8 @@ class DetHeadMixin(BaseMixin):
         out = {'pred_logits': outputs_class, 'pred_boxes': outputs_coord}
         return out
 
+from sat.model.registry import model_registry
+@model_registry.register
 class YOLOS(ViTModel):
     def __init__(self, args, transformer=None, parallel_output=True, layernorm_epsilon=1e-6, **kwargs):
         super().__init__(args, transformer=transformer, parallel_output=parallel_output, layernorm_epsilon=layernorm_epsilon, **kwargs)

--- a/sat/model/registry.py
+++ b/sat/model/registry.py
@@ -1,0 +1,23 @@
+class Registry:
+    def __init__(self, name):
+        self.name = name
+        self.member = {}
+
+    def register(self, cls):
+        if type(cls) is str:
+            def func(f):
+                self.member[cls] = f
+                return f
+            return func
+        self.member[cls.__name__] = cls
+        return cls
+    
+    def get(self, name):
+        if name not in self.member:
+            raise ValueError(f'model_class {name} not found.')
+        return self.member[name]
+    
+    def __repr__(self):
+        return 'Registry: ' + self.name + " " + str(self.member)
+
+model_registry = Registry('sat_models')


### PR DESCRIPTION
I made three modifications in this commit:

1. Use Registry to support dynamic loading. So users can add a `model_registry.register` decorator to model, then the model will support `AutoModel.from_pretrained`.
2. Add `build_only` argument to `from_pretrained`. This helps in some cases where users only want to build model using `model_config.json` without loading checkpoint weights.
3. Fix some typo in README.md.