### PR TITLE
dynamic loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 0. change the package name from `SwissArmyTransformer` to `sat` when importing, e.g. `from sat import get_args`.
 1. delete all `--sandwich-ln` in you script, use `layernorm-order='sandwich'`.
 2. change order `from_pretrained(args, name) => from_pretrained(name, args)`.
-4. We can directly use `from sat.model import AutoModel;model, args = AutoModel.from_pretrained(‘roberta-base’)` to load model in `model-only` mode, instead of initializing the sat first. 
+4. We can directly use `from sat.model import AutoModel;model, args = AutoModel.from_pretrained('roberta-base')` to load model in `model-only` mode, instead of initializing the sat first. 
 
 ## Install
 ```
@@ -171,7 +171,7 @@ TO BE RELEASED SOON...
 # Citation
 Currently we don't have a paper, so you don't need to formally cite us!~ 
 
-If this project helps your research or engineering, use `\footnote{https://github.com/THUDM/sat}` to mention us and recommend `sat` to others.
+If this project helps your research or engineering, use `\footnote{https://github.com/THUDM/SwissArmyTransformer}` to mention us and recommend `SwissArmyTransformer` to others.
 
 The tutorial for contributing sat is on the way!
 

--- a/sat/model/registry.py
+++ b/sat/model/registry.py
@@ -1,0 +1,29 @@
+class Registry:
+    def __init__(self, name):
+        self.name = name
+        self.member = {}
+
+    def register(self, cls):
+        if type(cls) is str:
+            def func(f):
+                self.member[cls] = f
+                return f
+            return func
+        self.member[cls.__name__] = cls
+        return cls
+    
+    def get(self, name):
+        if name not in self.member:
+            raise ValueError(f'model_class {name} not found.')
+        return self.member[name]
+    
+    def __repr__(self):
+        return 'Registry: ' + self.name + " " + str(self.member)
+
+model_registry = Registry('sat_models')
+
+class MetaModel(type):
+    def __new__(cls, clsname, bases, attrs):
+        newclass = super().__new__(cls, clsname, bases, attrs)
+        model_registry.register(newclass)
+        return newclass


### PR DESCRIPTION
I made three modifications in this commit:

1. Use `Registry` and `MetaModel` to support dynamic loading. Models inherent from `BaseModel` will automatically registered. Users can also add a `@model_registry.register` decorator to model to support `AutoModel.from_pretrained`.
2. Add `build_only` argument to from_pretrained. This helps in some cases where users only want to build model using `model_config.json` without loading checkpoint weights.
3. Fix some typo in README.md.

For use cases about 1, I think it may helpful for two cases:

1. Users may want to load models with different model classes sometimes. So users don't need to add redundant `if` statements, just use AutoModel.
2. There may be some third-party package based on sat under some other license in the future. They can also contribute to us without adding their models in model/official.